### PR TITLE
Fix typo: data source domain

### DIFF
--- a/chinaemu/View/AboutView.swift
+++ b/chinaemu/View/AboutView.swift
@@ -32,7 +32,7 @@ struct AboutView: View {
                     HStack {
                         Text("数据来源").font(.footnote)
                         Spacer()
-                        Text("rail.rl").font(.footnote)
+                        Text("rail.re").font(.footnote)
                     }
                     
                 }


### PR DESCRIPTION
数据来源rail.re错写为rail.rl，pr中已更正